### PR TITLE
Update FactorialCalculatorFrame2.java

### DIFF
--- a/18_Swing2/src/main/java/hr/fer/oop/swing2/example02/FactorialCalculatorFrame2.java
+++ b/18_Swing2/src/main/java/hr/fer/oop/swing2/example02/FactorialCalculatorFrame2.java
@@ -144,7 +144,7 @@ public class FactorialCalculatorFrame2 extends JFrame {
                 }
 
                 //publish progress update
-                publish((int) Math.round((i * 100) / number));
+                publish((i * 100) / number);
             }
 
             return factorial;


### PR DESCRIPTION
(int) Math.round((i * 100) / number) je redundantno.
-> (i * 100) / number je već cjelobrojno dijeljenje (vraća int)
-> Math.round prima float, dakle događa se nepotreban cast iz tipa int u tip float
-> Math.round vraća int, dakle redundantan je eksplicitni cast u integer ((int) Math.round)