### PR TITLE
9. auditorne Anagrami: Ispravi sortWord

### DIFF
--- a/Exercises/09_Recapitulation/src/main/java/hr/fer/oop/anagrams/Solution.java
+++ b/Exercises/09_Recapitulation/src/main/java/hr/fer/oop/anagrams/Solution.java
@@ -27,16 +27,9 @@ public class Solution {
   }
 
   private static String sortWord(String word) {
-    Set<Character> sorted = new TreeSet<>();
-
-    for(int i = 0; i < word.length(); i++)
-      sorted.add(word.charAt(i));
-
-    StringBuilder sb = new StringBuilder();
-    for(char c: sorted)
-      sb.append(c);
-
-    return sb.toString();
+    char[] characters = word.toCharArray();
+    Arrays.sort(characters);
+    return new String(characters);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
sortWord funkcija prethodno je koristila TreeSet za automatsko sortanje. Čini se kao jednostavno rješenje, ali za vrlo jednostavan i osnovan primjer daje pogrešan ispis:
```java
String[] input = {"vatra", "trava", "vrata", "vatr"};
```
```
pogrešan ispis:
[vatra, trava, vrata, vatr]
```
U ovoj situaciji riječ "vatr" se službenim rješenjem smatra anagramom ostalih riječi, što je očigledno pogrešno jer riječi nisu iste duljine pa nemaju ni isti broj jedinstvenih znakova. To se događa jer TreeSet ne dozvoljava duplikate znakova, pa tako "pojede" dvostruko slovo `a` u prve tri zadane riječi.

Ispravljeno rješenje jednostavno pretvara String u niz znakova, sortira ga te vraća kao novi String. Tako će sortirana riječ pravilno sadržavati višestruke znakove. Uz to je i mnogo jednostavnije i čitljivije od prijašnjeg eksplicitnog kopiranja u Set i izvan Seta u novi String.
```
ispravan ispis:
[vatra, trava, vrata]
[vatr]
```